### PR TITLE
chore: reative-mongo-client 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,6 +19,7 @@ repositories {
 dependencies {
 	implementation(platform("io.kotest:kotest-bom:5.5.5"))
 	implementation("org.springframework.boot:spring-boot-starter-rsocket")
+	implementation("org.springframework.boot:spring-boot-starter-data-mongodb-reactive")
 	implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 	implementation("io.projectreactor.kotlin:reactor-kotlin-extensions")
 	implementation("org.jetbrains.kotlin:kotlin-reflect")
@@ -30,6 +31,7 @@ dependencies {
 	testImplementation("io.kotest:kotest-assertions-core")
 	testImplementation("io.kotest:kotest-property")
 	testImplementation("org.testcontainers:testcontainers:1.17.6")
+	testImplementation("org.testcontainers:mongodb:1.18.0")
 	testImplementation("io.kotest.extensions:kotest-extensions-testcontainers:1.3.4")
 	testImplementation("io.kotest.extensions:kotest-extensions-spring:1.1.2")
 	testImplementation("org.springframework.boot:spring-boot-starter-test")

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,19 @@
+# compose 파일 버전
+version: "3"
+services:
+  # 서비스 명
+  mongo:
+    # 사용할 이미지
+    image: mongo:latest
+    # 컨테이너 실행 시 재시작
+    restart: always
+    # 접근 포트 설정 (컨테이너 외부:컨테이너 내부)
+    ports:
+      - "27017:27017"
+    # 환경 변수 설정
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: admin
+      MONGO_INITDB_ROOT_PASSWORD: password
+    # 볼륨 설정
+    volumes:
+      - ./data/mongo/:/var/lib/mongo/data

--- a/src/main/kotlin/talk/messageService/config/MongoConfig.kt
+++ b/src/main/kotlin/talk/messageService/config/MongoConfig.kt
@@ -1,0 +1,10 @@
+package talk.messageService.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.mongodb.config.EnableReactiveMongoAuditing
+import org.springframework.data.mongodb.repository.config.EnableReactiveMongoRepositories
+
+@Configuration
+@EnableReactiveMongoRepositories
+@EnableReactiveMongoAuditing
+class MongoConfig

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -6,7 +6,9 @@ spring:
       transport: websocket
       port: 8080
       mapping-path: /message-service
-
+  data:
+    mongodb:
+      uri: "mongodb://admin:password@localhost:27017/message_service"
 logging:
   level:
     talk:

--- a/src/test/kotlin/talk/messageService/config/ExtensionConfig.kt
+++ b/src/test/kotlin/talk/messageService/config/ExtensionConfig.kt
@@ -1,0 +1,18 @@
+package talk.messageService.config
+
+import io.kotest.core.config.AbstractProjectConfig
+import io.kotest.core.extensions.Extension
+import io.kotest.extensions.spring.SpringExtension
+import org.testcontainers.containers.MongoDBContainer
+import org.testcontainers.utility.DockerImageName
+
+object ExtensionConfig: AbstractProjectConfig() {
+    val mongoDBContainer = MongoDBContainer(DockerImageName.parse("mongo:4.0.10"))
+    init {
+        mongoDBContainer.start()
+        System.setProperty("spring.data.mongodb.url", mongoDBContainer.replicaSetUrl)
+    }
+    override fun extensions(): List<Extension> {
+        return super.extensions().plus(SpringExtension)
+    }
+}


### PR DESCRIPTION
## 요약
- spring-boot-starter-data-mongo-reactive 추가
- mongo-test-container 추가