### PR TITLE
feat: chat-message 도메인 추가

### DIFF
--- a/src/main/kotlin/talk/messageService/chatMessage/ChatMessage.kt
+++ b/src/main/kotlin/talk/messageService/chatMessage/ChatMessage.kt
@@ -1,0 +1,64 @@
+package talk.messageService.chatMessage
+
+import org.bson.types.ObjectId
+import org.springframework.data.annotation.CreatedBy
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.Id
+import org.springframework.data.annotation.LastModifiedBy
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.mongodb.core.mapping.Document
+import java.time.Instant
+
+/**
+ * 채팅 메세지
+ */
+@Document
+data class ChatMessage(
+        /**
+         * 채팅 메세지 id
+         */
+        @Id
+        val id: ObjectId?,
+        /**
+         * 채팅 id
+         */
+        val chatId: String,
+        /**
+         * 채팅 참가자 id
+         */
+        val chatParticipantId: String,
+        /**
+         * 채팅 내용
+         */
+        val content: String,
+        /**
+         * 채팅 메세지 생성일
+         */
+        @CreatedDate
+        val createdAt: Instant?,
+        /**
+         * 채팅 메세지 작성자
+         */
+        @CreatedBy
+        val createdBy: String?
+) {
+
+    private constructor(builder: Builder) :
+            this(builder.id, builder.chatId!!, builder.chatParticipantId!!, builder.content!!, builder.createdAt, builder.createdBy)
+
+    companion object {
+        inline fun chatMessage(block: Builder.() -> Unit) = Builder().apply(block).build()
+    }
+
+    class Builder {
+        var id: ObjectId? = null
+        var chatId: String? = null
+        var chatParticipantId: String? = null
+        var content: String? = null
+        var createdAt: Instant? = null
+        var createdBy: String? = null
+        fun build(): ChatMessage {
+            return ChatMessage(this)
+        }
+    }
+}

--- a/src/main/kotlin/talk/messageService/chatMessage/ChatMessageRepository.kt
+++ b/src/main/kotlin/talk/messageService/chatMessage/ChatMessageRepository.kt
@@ -1,0 +1,6 @@
+package talk.messageService.chatMessage
+
+import org.bson.types.ObjectId
+import org.springframework.data.repository.kotlin.CoroutineCrudRepository
+
+interface ChatMessageRepository: CoroutineCrudRepository<ChatMessage, ObjectId>

--- a/src/main/kotlin/talk/messageService/config/MongoConfig.kt
+++ b/src/main/kotlin/talk/messageService/config/MongoConfig.kt
@@ -5,6 +5,6 @@ import org.springframework.data.mongodb.config.EnableReactiveMongoAuditing
 import org.springframework.data.mongodb.repository.config.EnableReactiveMongoRepositories
 
 @Configuration
-@EnableReactiveMongoRepositories
+@EnableReactiveMongoRepositories(basePackages = ["talk.messageService"])
 @EnableReactiveMongoAuditing
 class MongoConfig

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -8,7 +8,7 @@ spring:
       mapping-path: /message-service
   data:
     mongodb:
-      uri: "mongodb://admin:password@localhost:27017/message_service"
+      uri: mongodb://admin:password@localhost:27017/message_service
 logging:
   level:
     talk:

--- a/src/test/kotlin/talk/messageService/chatMessage/ChatMessageRepositoryTests.kt
+++ b/src/test/kotlin/talk/messageService/chatMessage/ChatMessageRepositoryTests.kt
@@ -1,0 +1,37 @@
+package talk.messageService.chatMessage
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.comparables.shouldBeGreaterThan
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import kotlinx.coroutines.flow.firstOrNull
+import talk.messageService.chatMessage.ChatMessage.Companion.chatMessage
+import talk.messageService.mongo.RepositoryTest
+
+@RepositoryTest
+class ChatMessageRepositoryTests(
+        private val repository: ChatMessageRepository
+) : BehaviorSpec({
+    Given("chat-message 데이터 생성") {
+        When("데이터 생성 성공한 경우") {
+            beforeTest {
+                chatMessage {
+                    this.chatId = "a"
+                    this.chatParticipantId = "b"
+                    this.content = "c"
+                }.run { repository.save(this) }
+            }
+            Then("database 에 데이터가 존재한다") {
+                repository.findAll().firstOrNull().shouldNotBeNull().should {
+                    it.id shouldNotBe null
+                    it.chatId.length shouldBeGreaterThan 0
+                    it.chatParticipantId.length shouldBeGreaterThan 0
+                    it.content.length shouldBeGreaterThan 0
+                    it.createdAt shouldNotBe null
+                }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/talk/messageService/chatMessage/ChatMessageResourceTest.kt
+++ b/src/test/kotlin/talk/messageService/chatMessage/ChatMessageResourceTest.kt
@@ -1,4 +1,4 @@
-package talk.messageService.chat
+package talk.messageService.chatMessage
 
 import io.kotest.core.spec.style.BehaviorSpec
 import kotlinx.coroutines.delay

--- a/src/test/kotlin/talk/messageService/config/ExtensionConfig.kt
+++ b/src/test/kotlin/talk/messageService/config/ExtensionConfig.kt
@@ -10,7 +10,7 @@ object ExtensionConfig: AbstractProjectConfig() {
     val mongoDBContainer = MongoDBContainer(DockerImageName.parse("mongo:4.0.10"))
     init {
         mongoDBContainer.start()
-        System.setProperty("spring.data.mongodb.url", mongoDBContainer.replicaSetUrl)
+        System.setProperty("spring.data.mongodb.uri", mongoDBContainer.replicaSetUrl)
     }
     override fun extensions(): List<Extension> {
         return super.extensions().plus(SpringExtension)

--- a/src/test/kotlin/talk/messageService/mongo/RepositoryTest.kt
+++ b/src/test/kotlin/talk/messageService/mongo/RepositoryTest.kt
@@ -1,0 +1,9 @@
+package talk.messageService.mongo
+
+import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest
+import org.springframework.context.annotation.Import
+import talk.messageService.config.MongoConfig
+
+@DataMongoTest
+@Import(value = [MongoConfig::class])
+annotation class RepositoryTest


### PR DESCRIPTION
## 요약
- chat-message 도메인 생성
```kotlin

/**
 * 채팅 메세지
 */
@Document
data class ChatMessage(
        /**
         * 채팅 메세지 id
         */
        @Id
        val id: ObjectId?,
        /**
         * 채팅 id
         */
        val chatId: String,
        /**
         * 채팅 참가자 id
         */
        val chatParticipantId: String,
        /**
         * 채팅 내용
         */
        val content: String,
        /**
         * 채팅 메세지 생성일
         */
        @CreatedDate
        val createdAt: Instant?,
        /**
         * 채팅 메세지 작성자
         */
        @CreatedBy
        val createdBy: String?
)
```