### PR TITLE
refactor: 채팅 메세지 클라이언트로 발송 로직 개선

### DIFF
--- a/src/main/kotlin/talk/messageService/chatMessage/ChatMessageResource.kt
+++ b/src/main/kotlin/talk/messageService/chatMessage/ChatMessageResource.kt
@@ -1,7 +1,6 @@
 package talk.messageService.chatMessage
 
 import kotlinx.coroutines.flow.*
-import org.slf4j.LoggerFactory
 import org.springframework.messaging.handler.annotation.DestinationVariable
 import org.springframework.messaging.handler.annotation.MessageMapping
 import org.springframework.messaging.handler.annotation.Payload
@@ -9,16 +8,14 @@ import org.springframework.stereotype.Controller
 
 @Controller
 class ChatMessageResource(
-        private val chatMessageService: ChatMessageService
+        private val chatMessageService: ChatMessageService,
+        private val chatMessageStreamService: ChatMessageStreamService
 ) {
-    private val logger = LoggerFactory.getLogger(this.javaClass)
-
     /**
      * client 로부터 메세지를 받아서 저장
      */
     @MessageMapping(value = ["stream.chats.{id}.message"])
     suspend fun receive(@DestinationVariable id: String, @Payload inboundMessages: Flow<ChatMessagePayload>) {
-        logger.debug("receive message: $id")
         chatMessageService.post(id, inboundMessages)
     }
 
@@ -26,9 +23,6 @@ class ChatMessageResource(
      * client 로 메세지 전달
      */
     @MessageMapping(value = ["stream.chats.{id}.message"])
-    fun send(@DestinationVariable id: String): Flow<ChatMessageVM> = chatMessageService.stream()
-            .onStart {
-                logger.debug("send message: $id")
-                emitAll(chatMessageService.latest(id))
-            }
+    fun send(@DestinationVariable id: String): Flow<ChatMessageVM> =
+            chatMessageStreamService.watchChanges(id)
 }

--- a/src/main/kotlin/talk/messageService/chatMessage/ChatMessageService.kt
+++ b/src/main/kotlin/talk/messageService/chatMessage/ChatMessageService.kt
@@ -8,10 +8,6 @@ import talk.messageService.chatMessage.ChatMessage.Companion.chatMessage
 class ChatMessageService(
         private val repository: ChatMessageRepository
 ) {
-    val sender: MutableSharedFlow<ChatMessageVM> = MutableSharedFlow()
-
-    fun stream(): Flow<ChatMessageVM> = sender
-
     suspend fun post(chatId: String, messages: Flow<ChatMessagePayload>) =
             messages
                     .map {
@@ -22,12 +18,5 @@ class ChatMessageService(
                         }.run {
                             repository.save(this)
                         }
-                    }
-                    .onEach {
-                        sender.emit(it.toView())
                     }.collect()
-
-    fun latest(chatId: String): Flow<ChatMessageVM> =
-            repository.findAllByChatId(chatId).map(ChatMessage::toView)
-
 }

--- a/src/main/kotlin/talk/messageService/chatMessage/ChatMessageStreamService.kt
+++ b/src/main/kotlin/talk/messageService/chatMessage/ChatMessageStreamService.kt
@@ -1,0 +1,29 @@
+package talk.messageService.chatMessage
+
+import com.mongodb.client.model.changestream.OperationType
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.reactive.asFlow
+import org.slf4j.LoggerFactory
+import org.springframework.data.mongodb.core.ReactiveMongoTemplate
+import org.springframework.stereotype.Service
+import java.time.Instant
+
+@Service
+class ChatMessageStreamService(
+        private val reactiveMongoTemplate: ReactiveMongoTemplate
+) {
+    private val logger = LoggerFactory.getLogger(this.javaClass)
+
+    fun watchChanges(id: String): Flow<ChatMessageVM> =
+            reactiveMongoTemplate.changeStream(ChatMessage::class.java)
+                    .watchCollection("chatMessage")
+                    .resumeAt(Instant.now())
+                    .listen()
+                    .asFlow()
+                    .filter { it.operationType == OperationType.INSERT }
+                    .map { it.body!!.toView() }
+                    .catch { logger.error("chat-message change stream error: ${it.message}") }
+}

--- a/src/test/kotlin/talk/messageService/chatMessage/ChatMessageResourceTest.kt
+++ b/src/test/kotlin/talk/messageService/chatMessage/ChatMessageResourceTest.kt
@@ -1,10 +1,11 @@
 package talk.messageService.chatMessage
 
 import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.reactor.asFlux
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.messaging.rsocket.RSocketRequester
 import org.springframework.messaging.rsocket.dataWithType
@@ -12,18 +13,43 @@ import org.springframework.messaging.rsocket.retrieveFlow
 import org.springframework.messaging.rsocket.retrieveFlux
 import reactor.test.StepVerifier
 import java.time.Duration
+import java.util.concurrent.BlockingQueue
+import java.util.concurrent.LinkedBlockingQueue
+
 
 @SpringBootTest
 class ChatMessageResourceTest(
         private val rSocketRequester: RSocketRequester,
-        private val repository: ChatMessageRepository
+        private val repository: ChatMessageRepository,
+        private val chatMessageStreamService: ChatMessageStreamService
 ) : BehaviorSpec({
     Given("chat 메세지 발신, 수신 stream 확인하기") {
 
         fun chatStream(id: String) = rSocketRequester.route("stream.chats.$id.message")
 
         When("chat 메세지 정상 발송한 경우") {
+            beforeTest {
+                repository.deleteAll()
+            }
+            Then("chatMessageStreamService > 1개의 메세지가 정상 수신된다") {
+                val documents: BlockingQueue<ChatMessageVM> = LinkedBlockingQueue(100)
+                val disposable = chatMessageStreamService.watchChanges("a")
+                        .asFlux()
+                        .doOnNext(documents::add)
+                        .subscribe()
+                val payload = ChatMessagePayload("a", "b")
+                chatStream("a").dataWithType(
+                        flow {
+                            emit(payload)
+                        }
+                ).retrieveFlow<Unit>().collect()
+                delay(1000)
+
+                documents.size shouldBe 1
+                disposable.dispose()
+            }
             Then("1개의 메세지가 정상 수신된다") {
+                val received = chatStream("a").retrieveFlux<ChatMessageVM>()
                 val payload = ChatMessagePayload("a", "b")
                 chatStream("a").dataWithType(
                         flow {
@@ -31,13 +57,11 @@ class ChatMessageResourceTest(
                         }
                 ).retrieveFlow<Unit>().collect()
 
-                val received = chatStream("a").retrieveFlux<ChatMessageVM>()
-                delay(1000)
-                val view = repository.findAll().first().toView()
                 StepVerifier.create(received)
-                        .expectNext(view)
+                        .expectNextCount(1)
                         .thenCancel()
                         .verify(Duration.ofSeconds(2))
+
             }
         }
     }

--- a/src/test/kotlin/talk/messageService/chatMessage/ChatMessageResourceTest.kt
+++ b/src/test/kotlin/talk/messageService/chatMessage/ChatMessageResourceTest.kt
@@ -28,7 +28,7 @@ class ChatMessageResourceTest(
         fun chatStream(id: String) = rSocketRequester.route("stream.chats.$id.message")
 
         When("chat 메세지 정상 발송한 경우") {
-            beforeTest {
+            beforeEach {
                 repository.deleteAll()
             }
             Then("chatMessageStreamService > 1개의 메세지가 정상 수신된다") {
@@ -61,7 +61,6 @@ class ChatMessageResourceTest(
                         .expectNextCount(1)
                         .thenCancel()
                         .verify(Duration.ofSeconds(2))
-
             }
         }
     }

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -12,3 +12,7 @@ logging:
   level:
     talk:
       messageService: DEBUG
+    org:
+      springframework:
+        data:
+          mongodb: DEBUG


### PR DESCRIPTION
## 요약
- CDC 방식으로 데이터가 추가된 경우, client 에게 메세지를 보내는 로직 추가
### mongodb
- chang stream
- watchCollection
- resumeAt